### PR TITLE
Change DotNet executable args order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.1' //needs git repository with filled HEAD (at least one commit)
+    id 'net.wooga.plugins' version '2.2.3'
 }
 
 group 'net.wooga.gradle'
@@ -52,7 +52,7 @@ dependencies {
     api 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.2.0'
     implementation 'gradle.plugin.net.wooga.gradle:atlas-github:2.+'
     testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.2.0'
-    testImplementation 'org.ajoberstar.grgit:grgit-core:4.1.0'
+    testImplementation 'org.ajoberstar.grgit:grgit-core:4.+'
 }
 
 configurations.all {

--- a/src/main/groovy/wooga/gradle/dotnetsonar/tasks/internal/DotNet.groovy
+++ b/src/main/groovy/wooga/gradle/dotnetsonar/tasks/internal/DotNet.groovy
@@ -22,8 +22,8 @@ class DotNet implements SolutionBuildTool {
             execSpec.executable = executable.absolutePath
             execSpec.environment(environment)
             execSpec.args("build")
-            execSpec.args(*extraArgs)
             execSpec.args(solution.absolutePath)
+            execSpec.args(*extraArgs)
         }.throwsOnFailure()
     }
 

--- a/src/test/groovy/wooga/gradle/dotnetsonar/tasks/internal/DotNetSpec.groovy
+++ b/src/test/groovy/wooga/gradle/dotnetsonar/tasks/internal/DotNetSpec.groovy
@@ -22,7 +22,7 @@ class DotNetSpec extends Specification {
 
         then:
         shell.lastExecSpec.executable == executable.absolutePath
-        shell.lastExecSpec.args == ["build"] + extraArgs + [solution.absolutePath]
+        shell.lastExecSpec.args == ["build"] + [solution.absolutePath] + extraArgs
         shell.lastExecSpec.environment.entrySet().containsAll(environment.entrySet())
 
         where:


### PR DESCRIPTION
## Description

Fixed small bug where dotnet executable extra args were positioned before the solution path, when they should be after it. 

## Changes
* ![FIX] argument order for dotnet executable


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
